### PR TITLE
Allow super admin login without tenant

### DIFF
--- a/clothing-inspection-backend/routes/userRoutes.js
+++ b/clothing-inspection-backend/routes/userRoutes.js
@@ -104,12 +104,19 @@ router.post('/login', loginLimiter, async (req, res) => {
   try {
     const { tenantId, username, password } = req.body;
 
-    if(!tenantId) return res.status(400).json({ message: 'tenantId is required' });
-
-    const user = await User.findOne({ where: { username, tenant_id: tenantId } });
+    // 사용자명을 기준으로 먼저 조회하여 슈퍼 어드민 계정은
+    // 테넌트 ID 없이도 로그인할 수 있도록 허용합니다.
+    const user = await User.findOne({ where: { username } });
 
     if (!user) {
       return res.status(401).json({ message: '사용자를 찾을 수 없습니다.' });
+    }
+
+    // 일반 사용자는 tenantId가 필수이며, 계정의 tenant_id와 일치해야 합니다.
+    if (user.role !== 'super_admin') {
+      if (!tenantId || user.tenant_id !== tenantId) {
+        return res.status(401).json({ message: 'tenantId가 일치하지 않습니다.' });
+      }
     }
 
     // 비밀번호 검증


### PR DESCRIPTION
## Summary
- Permit super admin to authenticate without specifying a tenant ID
- Validate tenant ID only for non-super-admin users during login

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6899fe0deb5483289358c6289dd50fd5